### PR TITLE
Fix container option check

### DIFF
--- a/aws_browser/cli.py
+++ b/aws_browser/cli.py
@@ -28,7 +28,7 @@ def run():
     stdout: Optional[bool] = args.stdout
 
     assert (container_name is not None) != (
-        container_name_from_vault is not None
+        container_name_from_vault == True
     ), "You can only specify one --container-name option"
 
     if browser and browser.endswith(CONTAINER_SUFFIX):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-browser"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Ben Bridts"]
 


### PR DESCRIPTION
Option --container-name did not work as --container-name-from-vault is always True or False, but never "None".