### PR TITLE
Implemented functionality for long-lived credentials

### DIFF
--- a/aws_browser/aws.py
+++ b/aws_browser/aws.py
@@ -1,6 +1,5 @@
 import dataclasses
 import json
-import uuid
 from typing import Optional
 
 import boto3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-browser"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Ben Bridts"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-browser"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Ben Bridts", "Cloudar"]
 


### PR DESCRIPTION
It will now try to get a federation token if a session token is not
present in the current credentials. Additionally, It will assert to
see if the get caller identity is in fact an IAM user.